### PR TITLE
Extensible streaming

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-	project.version = '3.1.0'
+	project.version = '4.0.0'
 	project.group = 'de.pottgames'
 }
 

--- a/core/src/jmh/java/de/pottgames/tuningfork/benchmark/Load16BitWav.java
+++ b/core/src/jmh/java/de/pottgames/tuningfork/benchmark/Load16BitWav.java
@@ -9,6 +9,9 @@ import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.TearDown;
 
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.backends.lwjgl3.Lwjgl3Files;
+
 import de.pottgames.tuningfork.Audio;
 import de.pottgames.tuningfork.AudioConfig;
 import de.pottgames.tuningfork.SoundBuffer;
@@ -29,6 +32,7 @@ public class Load16BitWav {
 
     @Setup(Level.Iteration)
     public void setup() {
+        Gdx.files = new Lwjgl3Files();
         final AudioConfig config = new AudioConfig();
         config.setLogger(new MockLogger());
         this.audio = Audio.init(config);

--- a/core/src/jmh/java/de/pottgames/tuningfork/benchmark/Load8BitWav.java
+++ b/core/src/jmh/java/de/pottgames/tuningfork/benchmark/Load8BitWav.java
@@ -9,6 +9,9 @@ import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.TearDown;
 
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.backends.lwjgl3.Lwjgl3Files;
+
 import de.pottgames.tuningfork.Audio;
 import de.pottgames.tuningfork.AudioConfig;
 import de.pottgames.tuningfork.SoundBuffer;
@@ -29,6 +32,7 @@ public class Load8BitWav {
 
     @Setup(Level.Iteration)
     public void setup() {
+        Gdx.files = new Lwjgl3Files();
         final AudioConfig config = new AudioConfig();
         config.setLogger(new MockLogger());
         this.audio = Audio.init(config);

--- a/core/src/jmh/java/de/pottgames/tuningfork/benchmark/LoadImaAdpcmWav.java
+++ b/core/src/jmh/java/de/pottgames/tuningfork/benchmark/LoadImaAdpcmWav.java
@@ -9,6 +9,9 @@ import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.TearDown;
 
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.backends.lwjgl3.Lwjgl3Files;
+
 import de.pottgames.tuningfork.Audio;
 import de.pottgames.tuningfork.AudioConfig;
 import de.pottgames.tuningfork.SoundBuffer;
@@ -29,6 +32,7 @@ public class LoadImaAdpcmWav {
 
     @Setup(Level.Iteration)
     public void setup() {
+        Gdx.files = new Lwjgl3Files();
         final AudioConfig config = new AudioConfig();
         config.setLogger(new MockLogger());
         this.audio = Audio.init(config);

--- a/core/src/jmh/java/de/pottgames/tuningfork/benchmark/LoadQuality10Ogg.java
+++ b/core/src/jmh/java/de/pottgames/tuningfork/benchmark/LoadQuality10Ogg.java
@@ -1,7 +1,6 @@
 package de.pottgames.tuningfork.benchmark;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 
 import org.openjdk.jmh.annotations.Benchmark;
@@ -25,7 +24,7 @@ public class LoadQuality10Ogg {
 
     @Benchmark
     public void load() throws FileNotFoundException {
-        this.soundBuffer = OggLoader.load(new FileInputStream(new File("src/jmh/resources/bench_10.ogg")));
+        this.soundBuffer = OggLoader.load(new File("src/jmh/resources/bench_10.ogg"));
     }
 
 

--- a/core/src/jmh/java/de/pottgames/tuningfork/benchmark/LoadQuality10Ogg.java
+++ b/core/src/jmh/java/de/pottgames/tuningfork/benchmark/LoadQuality10Ogg.java
@@ -10,6 +10,9 @@ import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.TearDown;
 
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.backends.lwjgl3.Lwjgl3Files;
+
 import de.pottgames.tuningfork.Audio;
 import de.pottgames.tuningfork.AudioConfig;
 import de.pottgames.tuningfork.OggLoader;
@@ -30,6 +33,7 @@ public class LoadQuality10Ogg {
 
     @Setup(Level.Iteration)
     public void setup() {
+        Gdx.files = new Lwjgl3Files();
         final AudioConfig config = new AudioConfig();
         config.setLogger(new MockLogger());
         this.audio = Audio.init(config);

--- a/core/src/jmh/java/de/pottgames/tuningfork/benchmark/LoadQuality5Ogg.java
+++ b/core/src/jmh/java/de/pottgames/tuningfork/benchmark/LoadQuality5Ogg.java
@@ -10,6 +10,9 @@ import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.TearDown;
 
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.backends.lwjgl3.Lwjgl3Files;
+
 import de.pottgames.tuningfork.Audio;
 import de.pottgames.tuningfork.AudioConfig;
 import de.pottgames.tuningfork.OggLoader;
@@ -30,6 +33,7 @@ public class LoadQuality5Ogg {
 
     @Setup(Level.Iteration)
     public void setup() {
+        Gdx.files = new Lwjgl3Files();
         final AudioConfig config = new AudioConfig();
         config.setLogger(new MockLogger());
         this.audio = Audio.init(config);

--- a/core/src/jmh/java/de/pottgames/tuningfork/benchmark/LoadQuality5Ogg.java
+++ b/core/src/jmh/java/de/pottgames/tuningfork/benchmark/LoadQuality5Ogg.java
@@ -1,7 +1,6 @@
 package de.pottgames.tuningfork.benchmark;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 
 import org.openjdk.jmh.annotations.Benchmark;
@@ -25,7 +24,7 @@ public class LoadQuality5Ogg {
 
     @Benchmark
     public void load() throws FileNotFoundException {
-        this.soundBuffer = OggLoader.load(new FileInputStream(new File("src/jmh/resources/bench_5.ogg")));
+        this.soundBuffer = OggLoader.load(new File("src/jmh/resources/bench_5.ogg"));
     }
 
 

--- a/core/src/main/java/de/pottgames/tuningfork/Audio.java
+++ b/core/src/main/java/de/pottgames/tuningfork/Audio.java
@@ -381,7 +381,7 @@ public class Audio implements Disposable {
      *
      * @deprecated This method will be removed in the future. Use {@link SoundBuffer#play()} instead.
      */
-    @Deprecated(since = "3.1.0", forRemoval = true)
+    @Deprecated
     public void play(SoundBuffer buffer) {
         final BufferedSoundSource source = this.obtainRelativeSource(buffer, false);
         source.play();
@@ -397,7 +397,7 @@ public class Audio implements Disposable {
      *
      * @deprecated This method will be removed in the future. Use {@link SoundBuffer#play(Filter)} instead.
      */
-    @Deprecated(since = "3.1.0", forRemoval = true)
+    @Deprecated
     public void play(SoundBuffer buffer, Filter filter) {
         final BufferedSoundSource source = this.obtainRelativeSource(buffer, false);
         source.setFilter(filter);
@@ -414,7 +414,7 @@ public class Audio implements Disposable {
      *
      * @deprecated This method will be removed in the future. Use {@link SoundBuffer#play(SoundEffect)} instead.
      */
-    @Deprecated(since = "3.1.0", forRemoval = true)
+    @Deprecated
     public void play(SoundBuffer buffer, SoundEffect effect) {
         final BufferedSoundSource source = this.obtainRelativeSource(buffer, false);
         source.attachEffect(effect);
@@ -431,7 +431,7 @@ public class Audio implements Disposable {
      *
      * @deprecated This method will be removed in the future. Use {@link SoundBuffer#play(float)} instead.
      */
-    @Deprecated(since = "3.1.0", forRemoval = true)
+    @Deprecated
     public void play(SoundBuffer buffer, float volume) {
         final BufferedSoundSource source = this.obtainRelativeSource(buffer, false);
         source.setVolume(volume);
@@ -449,7 +449,7 @@ public class Audio implements Disposable {
      *
      * @deprecated This method will be removed in the future. Use {@link SoundBuffer#play(float, Filter)} instead.
      */
-    @Deprecated(since = "3.1.0", forRemoval = true)
+    @Deprecated
     public void play(SoundBuffer buffer, float volume, Filter filter) {
         final BufferedSoundSource source = this.obtainRelativeSource(buffer, false);
         source.setVolume(volume);
@@ -468,7 +468,7 @@ public class Audio implements Disposable {
      *
      * @deprecated This method will be removed in the future. Use {@link SoundBuffer#play(float, SoundEffect)} instead.
      */
-    @Deprecated(since = "3.1.0", forRemoval = true)
+    @Deprecated
     public void play(SoundBuffer buffer, float volume, SoundEffect effect) {
         final BufferedSoundSource source = this.obtainRelativeSource(buffer, false);
         source.setVolume(volume);
@@ -487,7 +487,7 @@ public class Audio implements Disposable {
      *
      * @deprecated This method will be removed in the future. Use {@link SoundBuffer#play(float, float)} instead.
      */
-    @Deprecated(since = "3.1.0", forRemoval = true)
+    @Deprecated
     public void play(SoundBuffer buffer, float volume, float pitch) {
         final BufferedSoundSource source = this.obtainRelativeSource(buffer, false);
         source.setVolume(volume);
@@ -507,7 +507,7 @@ public class Audio implements Disposable {
      *
      * @deprecated This method will be removed in the future. Use {@link SoundBuffer#play(float, float, Filter)} instead.
      */
-    @Deprecated(since = "3.1.0", forRemoval = true)
+    @Deprecated
     public void play(SoundBuffer buffer, float volume, float pitch, Filter filter) {
         final BufferedSoundSource source = this.obtainRelativeSource(buffer, false);
         source.setVolume(volume);
@@ -528,7 +528,7 @@ public class Audio implements Disposable {
      *
      * @deprecated This method will be removed in the future. Use {@link SoundBuffer#play(float, float, SoundEffect)} instead.
      */
-    @Deprecated(since = "3.1.0", forRemoval = true)
+    @Deprecated
     public void play(SoundBuffer buffer, float volume, float pitch, SoundEffect effect) {
         final BufferedSoundSource source = this.obtainRelativeSource(buffer, false);
         source.setVolume(volume);
@@ -549,7 +549,7 @@ public class Audio implements Disposable {
      *
      * @deprecated This method will be removed in the future. Use {@link SoundBuffer#play(float, float, float)} instead.
      */
-    @Deprecated(since = "3.1.0", forRemoval = true)
+    @Deprecated
     public void play(SoundBuffer buffer, float volume, float pitch, float pan) {
         final BufferedSoundSource source = this.obtainRelativeSource(buffer, false);
         source.setVolume(volume);
@@ -572,7 +572,7 @@ public class Audio implements Disposable {
      *
      * @deprecated This method will be removed in the future. Use {@link SoundBuffer#play(float, float, float, SoundEffect)} instead.
      */
-    @Deprecated(since = "3.1.0", forRemoval = true)
+    @Deprecated
     public void play(SoundBuffer buffer, float volume, float pitch, float pan, SoundEffect effect) {
         final BufferedSoundSource source = this.obtainRelativeSource(buffer, false);
         source.setVolume(volume);
@@ -593,7 +593,7 @@ public class Audio implements Disposable {
      *
      * @deprecated This method will be removed in the future. Use {@link SoundBuffer#play3D(Vector3)} instead.
      */
-    @Deprecated(since = "3.1.0", forRemoval = true)
+    @Deprecated
     public void play3D(SoundBuffer buffer, Vector3 position) {
         final BufferedSoundSource source = this.obtainSource(buffer);
         source.setPosition(position);
@@ -611,7 +611,7 @@ public class Audio implements Disposable {
      *
      * @deprecated This method will be removed in the future. Use {@link SoundBuffer#play3D(Vector3, Filter)} instead.
      */
-    @Deprecated(since = "3.1.0", forRemoval = true)
+    @Deprecated
     public void play3D(SoundBuffer buffer, Vector3 position, Filter filter) {
         final BufferedSoundSource source = this.obtainSource(buffer);
         source.setPosition(position);
@@ -630,7 +630,7 @@ public class Audio implements Disposable {
      *
      * @deprecated This method will be removed in the future. Use {@link SoundBuffer#play3D(Vector3, SoundEffect)} instead.
      */
-    @Deprecated(since = "3.1.0", forRemoval = true)
+    @Deprecated
     public void play3D(SoundBuffer buffer, Vector3 position, SoundEffect effect) {
         final BufferedSoundSource source = this.obtainSource(buffer);
         source.setPosition(position);
@@ -650,7 +650,7 @@ public class Audio implements Disposable {
      *
      * @deprecated This method will be removed in the future. Use {@link SoundBuffer#play3D(Vector3, Filter, SoundEffect)} instead.
      */
-    @Deprecated(since = "3.1.0", forRemoval = true)
+    @Deprecated
     public void play3D(SoundBuffer buffer, Vector3 position, Filter filter, SoundEffect effect) {
         final BufferedSoundSource source = this.obtainSource(buffer);
         source.setPosition(position);
@@ -670,7 +670,7 @@ public class Audio implements Disposable {
      *
      * @deprecated This method will be removed in the future. Use {@link SoundBuffer#play3D(float, Vector3)} instead.
      */
-    @Deprecated(since = "3.1.0", forRemoval = true)
+    @Deprecated
     public void play3D(SoundBuffer buffer, float volume, Vector3 position) {
         final BufferedSoundSource source = this.obtainSource(buffer);
         source.setVolume(volume);
@@ -690,7 +690,7 @@ public class Audio implements Disposable {
      *
      * @deprecated This method will be removed in the future. Use {@link SoundBuffer#play3D(float, Vector3, Filter)} instead.
      */
-    @Deprecated(since = "3.1.0", forRemoval = true)
+    @Deprecated
     public void play3D(SoundBuffer buffer, float volume, Vector3 position, Filter filter) {
         final BufferedSoundSource source = this.obtainSource(buffer);
         source.setVolume(volume);
@@ -711,7 +711,7 @@ public class Audio implements Disposable {
      *
      * @deprecated This method will be removed in the future. Use {@link SoundBuffer#play3D(float, Vector3, SoundEffect)} instead.
      */
-    @Deprecated(since = "3.1.0", forRemoval = true)
+    @Deprecated
     public void play3D(SoundBuffer buffer, float volume, Vector3 position, SoundEffect effect) {
         final BufferedSoundSource source = this.obtainSource(buffer);
         source.setVolume(volume);
@@ -732,7 +732,7 @@ public class Audio implements Disposable {
      *
      * @deprecated This method will be removed in the future. Use {@link SoundBuffer#play3D(float, float, Vector3)} instead.
      */
-    @Deprecated(since = "3.1.0", forRemoval = true)
+    @Deprecated
     public void play3D(SoundBuffer buffer, float volume, float pitch, Vector3 position) {
         final BufferedSoundSource source = this.obtainSource(buffer);
         source.setVolume(volume);
@@ -754,7 +754,7 @@ public class Audio implements Disposable {
      *
      * @deprecated This method will be removed in the future. Use {@link SoundBuffer#play3D(float, float, Vector3, SoundEffect)} instead.
      */
-    @Deprecated(since = "3.1.0", forRemoval = true)
+    @Deprecated
     public void play3D(SoundBuffer buffer, float volume, float pitch, Vector3 position, SoundEffect effect) {
         final BufferedSoundSource source = this.obtainSource(buffer);
         source.setVolume(volume);

--- a/core/src/main/java/de/pottgames/tuningfork/OggLoader.java
+++ b/core/src/main/java/de/pottgames/tuningfork/OggLoader.java
@@ -14,10 +14,8 @@ package de.pottgames.tuningfork;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.InputStream;
 
+import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.files.FileHandle;
 import com.badlogic.gdx.utils.StreamUtils;
 
@@ -32,39 +30,23 @@ public abstract class OggLoader {
      *
      * @return the SoundBuffer
      */
-    public static SoundBuffer load(FileHandle file) {
-        return OggLoader.load(file.read());
+    public static SoundBuffer load(File file) {
+        return OggLoader.load(Gdx.files.absolute(file.getAbsolutePath()));
     }
 
 
     /**
-     * Loads an ogg into a {@link SoundBuffer}.
+     * Loads sound data from a {@link FileHandle} into a {@link SoundBuffer} using the ogg decoder and closes the stream afterwards.
      *
      * @param file
      *
      * @return the SoundBuffer
      */
-    public static SoundBuffer load(File file) {
-        try {
-            return OggLoader.load(new FileInputStream(file));
-        } catch (final FileNotFoundException e) {
-            throw new TuningForkRuntimeException(e);
-        }
-    }
-
-
-    /**
-     * Loads sound data from an {@link InputStream} into a {@link SoundBuffer} using the ogg decoder and closes the stream afterwards.
-     *
-     * @param stream
-     *
-     * @return the SoundBuffer
-     */
-    public static SoundBuffer load(InputStream stream) {
+    public static SoundBuffer load(FileHandle file) {
         SoundBuffer result = null;
         OggInputStream input = null;
         try {
-            input = new OggInputStream(stream);
+            input = new OggInputStream(file, null);
             final ByteArrayOutputStream output = new ByteArrayOutputStream(4096);
             final byte[] buffer = new byte[2048];
             while (!input.atEnd()) {

--- a/core/src/main/java/de/pottgames/tuningfork/WaveLoader.java
+++ b/core/src/main/java/de/pottgames/tuningfork/WaveLoader.java
@@ -29,20 +29,8 @@ public abstract class WaveLoader {
      *
      * @return the SoundBuffer
      */
-    public static SoundBuffer load(FileHandle file) {
-        SoundBuffer result = null;
-
-        WavInputStream input = null;
-        try {
-            input = new WavInputStream(file);
-            final byte[] buffer = new byte[(int) input.totalSamplesPerChannel() * (input.getBitsPerSample() / 8) * input.getChannels()];
-            input.read(buffer);
-            result = new SoundBuffer(buffer, input.getChannels(), input.getSampleRate(), input.getBitsPerSample(), input.getPcmDataType());
-        } finally {
-            StreamUtils.closeQuietly(input);
-        }
-
-        return result;
+    public static SoundBuffer load(File file) {
+        return WaveLoader.load(Gdx.files.absolute(file.getAbsolutePath()));
     }
 
 
@@ -53,12 +41,12 @@ public abstract class WaveLoader {
      *
      * @return the SoundBuffer
      */
-    public static SoundBuffer load(File file) {
+    public static SoundBuffer load(FileHandle file) {
         SoundBuffer result = null;
 
         WavInputStream input = null;
         try {
-            input = new WavInputStream(Gdx.files.absolute(file.getAbsolutePath()));
+            input = new WavInputStream(file);
             final byte[] buffer = new byte[(int) input.totalSamplesPerChannel() * (input.getBitsPerSample() / 8) * input.getChannels()];
             input.read(buffer);
             result = new SoundBuffer(buffer, input.getChannels(), input.getSampleRate(), input.getBitsPerSample(), input.getPcmDataType());

--- a/core/src/main/java/de/pottgames/tuningfork/WaveLoader.java
+++ b/core/src/main/java/de/pottgames/tuningfork/WaveLoader.java
@@ -13,10 +13,8 @@
 package de.pottgames.tuningfork;
 
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStream;
 
+import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.files.FileHandle;
 import com.badlogic.gdx.utils.StreamUtils;
 
@@ -49,30 +47,6 @@ public abstract class WaveLoader {
 
 
     /**
-     * Loads wav data into a {@link SoundBuffer} from an {@link InputStream} and closes the stream afterwards. The stream must start with a RIFF header.
-     *
-     * @param stream
-     *
-     * @return the SoundBuffer
-     */
-    public static SoundBuffer load(InputStream stream) {
-        SoundBuffer result = null;
-
-        WavInputStream input = null;
-        try {
-            input = new WavInputStream(stream);
-            final byte[] buffer = new byte[(int) input.totalSamplesPerChannel() * (input.getBitsPerSample() / 8) * input.getChannels()];
-            input.read(buffer);
-            result = new SoundBuffer(buffer, input.getChannels(), input.getSampleRate(), input.getBitsPerSample(), input.getPcmDataType());
-        } finally {
-            StreamUtils.closeQuietly(input);
-        }
-
-        return result;
-    }
-
-
-    /**
      * Loads a wav file into a {@link SoundBuffer}.
      *
      * @param file
@@ -84,12 +58,10 @@ public abstract class WaveLoader {
 
         WavInputStream input = null;
         try {
-            input = new WavInputStream(new FileInputStream(file));
+            input = new WavInputStream(Gdx.files.absolute(file.getAbsolutePath()));
             final byte[] buffer = new byte[(int) input.totalSamplesPerChannel() * (input.getBitsPerSample() / 8) * input.getChannels()];
             input.read(buffer);
             result = new SoundBuffer(buffer, input.getChannels(), input.getSampleRate(), input.getBitsPerSample(), input.getPcmDataType());
-        } catch (final IOException ex) {
-            throw new TuningForkRuntimeException(ex);
         } finally {
             StreamUtils.closeQuietly(input);
         }

--- a/core/src/main/java/de/pottgames/tuningfork/decoder/AudioStream.java
+++ b/core/src/main/java/de/pottgames/tuningfork/decoder/AudioStream.java
@@ -15,24 +15,80 @@ package de.pottgames.tuningfork.decoder;
 import java.io.Closeable;
 
 import de.pottgames.tuningfork.PcmFormat.PcmDataType;
+import de.pottgames.tuningfork.StreamedSoundSource;
 
+/**
+ * An audio stream interface that can be implemented to feed a {@link StreamedSoundSource}.
+ *
+ * @author Matthias
+ *
+ */
 public interface AudioStream extends Closeable {
 
+    /**
+     * Returns the duration in seconds or -1 if this information is not available.
+     *
+     * @return duration in seconds or -1 if the information is not available
+     */
+    float getDuration();
+
+
+    /**
+     * Resets the audio stream as if it was re-opened. Implementations are free to close themselves and provide a new AudioStream. The AudioStream returned by
+     * this function will be used, regardless of whether it is a new instance or the old one.
+     *
+     * @return an AudioStream
+     */
+    AudioStream reset();
+
+
+    /**
+     * Returns the number of audio channels.
+     *
+     * @return number of channels
+     */
     int getChannels();
 
 
+    /**
+     * Returns the sample rate.
+     *
+     * @return the sample rate
+     */
     int getSampleRate();
 
 
+    /**
+     * Returns the number of bits per sample, also known as the sample depth.
+     *
+     * @return the number of bits per sample
+     */
     int getBitsPerSample();
 
 
+    /**
+     * Reads bytes from the stream until the given array is full or the stream ends. Returns the number of bytes that were actually read.
+     *
+     * @param bytes the byte array to store the bytes in
+     *
+     * @return number of bytes read
+     */
     int read(byte[] bytes);
 
 
+    /**
+     * Returns the output data format of this AudioStream.
+     *
+     * @return the pcm data type
+     */
     PcmDataType getPcmDataType();
 
 
+    /**
+     * Returns true if the AudioStream is closed.
+     *
+     * @return true if closed, false if open
+     */
     boolean isClosed();
 
 }

--- a/core/src/test/java/de/pottgames/tuningfork/test/DeviceTest.java
+++ b/core/src/test/java/de/pottgames/tuningfork/test/DeviceTest.java
@@ -6,6 +6,9 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.List;
 
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.backends.lwjgl3.Lwjgl3Files;
+
 import de.pottgames.tuningfork.Audio;
 import de.pottgames.tuningfork.AudioConfig;
 import de.pottgames.tuningfork.AudioDeviceConfig;
@@ -19,6 +22,7 @@ public class DeviceTest {
 
     public static void main(String[] args) throws IOException, InterruptedException {
         System.out.println("Working Directory = " + System.getProperty("user.dir"));
+        Gdx.files = new Lwjgl3Files();
 
         // FETCH AVAILABLE DEVICES
         final List<String> deviceList = Audio.availableDevices();


### PR DESCRIPTION
This PR decouples StreamedSoundSource from the available implementations of AudioStream and uses only the interface. This makes it possible to build custom AudioStreams and play them via StreamedSoundSource. In a perfect world it would have been like this from the beginning, well I'm not perfect.

Extensive testing is needed as these are profound changes.