### PR TITLE
Add system event rerouting

### DIFF
--- a/core/src/main/java/de/pottgames/tuningfork/ALExtension.java
+++ b/core/src/main/java/de/pottgames/tuningfork/ALExtension.java
@@ -27,6 +27,7 @@ public enum ALExtension {
     ALC_SOFT_OUTPUT_MODE("ALC_SOFT_output_mode", true),
     ALC_SOFT_PAUSE_DEVICE("ALC_SOFT_pause_device", true),
     ALC_SOFT_REOPEN_DEVICE("ALC_SOFT_reopen_device", true),
+    ALC_SOFT_SYSTEM_EVENTS("ALC_SOFT_system_events", true),
     AL_EXT_ALAW("AL_EXT_ALAW", false),
     AL_EXT_BFORMAT("AL_EXT_BFORMAT", false),
     AL_EXT_DOUBLE("AL_EXT_DOUBLE", false),


### PR DESCRIPTION
## Summary
- add `ALC_SOFT_SYSTEM_EVENTS` enum constant
- update `SmartDeviceRerouter` to use ALC_SOFT_system_events callbacks when available and fall back to polling otherwise

## Testing
- `./gradlew test` *(fails: Could not resolve com.github.Hangman:FLAC-library-Java:90cee6f500)*

------
https://chatgpt.com/codex/tasks/task_e_68409ea4f4108326b11e33277d7680a8